### PR TITLE
Add Rule #108: Democratic Voting on New Rules Modifications

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -51,4 +51,5 @@
 
 #### 108: Democratic Change in New Rules
 
-> a) Whenever a new rule is to be elected, all players EXCEPT the one adding the rule must collectively decide on a change in the specific rule.>> The change(s) in the rule must be relevant to the rule itself, and may not be a completely seperate rule.
+> a) Whenever a new rule is to be proposed, all players EXCEPT the one adding the rule must collectively decide on a change in the specific rule.
+> The change(s) in the rule must be relevant to the rule itself, and may not be a completely seperate rule.

--- a/rules.md
+++ b/rules.md
@@ -46,3 +46,9 @@
 >
 > c) The total sum of points may not increase or decrease as a result of this amendment.
 
+
+
+
+#### 108: Democratic Change in New Rules
+
+> a) Whenever a new rule is to be elected, all players EXCEPT the one adding the rule must collectively decide on a change in the specific rule.>> The change(s) in the rule must be relevant to the rule itself, and may not be a completely seperate rule.


### PR DESCRIPTION
**Rules** #108

This new rule adds makes all newfound rules to be reviewed and modified by all players EXCEPT the one which proposes for the rule.