### PR TITLE
Rule #110: Banned Griefing

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -64,3 +64,5 @@
 #### 110: Griefing Banned
 
 > a) Editing to exisitng comments, adding labels, or sabotaging a thread or the rule itself is prohibited without the user nehind making the rule's permission to do so
+>
+> Punishes the people harshly with a virtual gulitine

--- a/rules.md
+++ b/rules.md
@@ -59,3 +59,8 @@
 > a) A player earns +1 point whenever he is successful to elect his rule.
 >
 > b) This does not earn you points if you approve someone else's rule, only the player gets a point.
+
+
+#### 110: Griefing Banned
+
+> a) Editing to exisitng comments, adding labels, or sabotaging a thread or the rule itself is prohibited without the user nehind making the rule's permission to do so

--- a/rules.md
+++ b/rules.md
@@ -65,4 +65,4 @@
 
 > a) Editing to exisitng comments, adding labels, or sabotaging a thread or the rule itself is prohibited without the user nehind making the rule's permission to do so
 >
-> Punishes the people harshly with a virtual gulitine
+> Punishes the people harshly with a virtual guillotine


### PR DESCRIPTION
This rule prohibits user from editing existing comments, adding flairs or sabotaging the rule or the rule's thread in any way without the permission to do so without the user behind making the rule.